### PR TITLE
Fixed Alpha Animals patch for 1.4

### DIFF
--- a/1.3/AlphaAnimals/Defs/AlphaAnimals/Hediffs_Local_AddedParts.xml
+++ b/1.3/AlphaAnimals/Defs/AlphaAnimals/Hediffs_Local_AddedParts.xml
@@ -46,7 +46,7 @@
 			<li>
 				<statOffsets>
 					<PsychicSensitivity>0.01</PsychicSensitivity>
-					<ToxicResistance>0.99</ToxicResistance>
+					<ToxicSensitivity>0.01</ToxicSensitivity>
 				</statOffsets>
 			</li>
 		</stages>
@@ -136,7 +136,7 @@
 				</capMods>
 				<statOffsets>
 					<PsychicSensitivity>0.02</PsychicSensitivity>
-					<ToxicResistance>0.98</ToxicResistance>
+					<ToxicSensitivity>0.02</ToxicSensitivity>
 				</statOffsets>
 			</li>
 		</stages>
@@ -221,7 +221,7 @@
 				</capMods>
 				<statOffsets>
 					<PsychicSensitivity>0.005</PsychicSensitivity>
-					<ToxicResistance>0.995</ToxicResistance>
+					<ToxicSensitivity>0.005</ToxicSensitivity>
 				</statOffsets>
 			</li>
 		</stages>
@@ -299,7 +299,7 @@
 				</capMods>
 				<statOffsets>
 					<PsychicSensitivity>0.02</PsychicSensitivity>
-					<ToxicResistance>0.98</ToxicResistance>
+					<ToxicSensitivity>0.02</ToxicSensitivity>
 				</statOffsets>
 			</li>
 		</stages>
@@ -386,7 +386,7 @@
 				</capMods>
 				<statOffsets>
 					<PsychicSensitivity>0.005</PsychicSensitivity>
-					<ToxicResistance>0.995</ToxicResistance>
+					<ToxicSensitivity>0.005</ToxicSensitivity>
 				</statOffsets>
 			</li>
 		</stages>

--- a/1.3/AlphaAnimals/Patches/AlphaAnimals/Hediffs_Local_AddedParts.xml
+++ b/1.3/AlphaAnimals/Patches/AlphaAnimals/Hediffs_Local_AddedParts.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<!-- mutant leg -->
+
+	<Operation Class="PatchOperationAddOrMerge">
+		<xpath>/Defs/ThingDef[@ParentName="AA_BodyPartMutantBase"][defName="AA_MutantLeg"]</xpath>
+		<value>
+			<comps>
+				<li Class="MSE2.CompProperties_IncludedChildParts">
+					<standardChildren>
+						<li>AA_MutantFoot</li>
+						<li>AA_MutantBone</li>
+					</standardChildren>
+				</li>
+			</comps>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[@ParentName="AA_BodyPartMutantBase"][defName="AA_MutantLeg"]/statBases</xpath>
+		<value>
+			<statBases>
+				<MarketValue>51</MarketValue>
+				<Mass>2</Mass>
+			</statBases>
+		</value>
+	</Operation>
+
+	<!-- mutant arm -->
+
+	<Operation Class="PatchOperationAddOrMerge">
+		<xpath>/Defs/ThingDef[@ParentName="AA_BodyPartMutantBase"][defName="AA_MutantArm"]</xpath>
+		<value>
+			<comps>
+				<li Class="MSE2.CompProperties_IncludedChildParts">
+					<standardChildren>
+						<li>AA_MutantHand</li>
+						<li>AA_MutantBone</li>
+					</standardChildren>
+				</li>
+			</comps>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[@ParentName="AA_BodyPartMutantBase"][defName="AA_MutantArm"]/statBases</xpath>
+		<value>
+			<statBases>
+				<MarketValue>51</MarketValue>
+				<Mass>2</Mass>
+			</statBases>
+		</value>
+	</Operation>
+
+	<!-- move verb from arm to hand -->
+
+	<Operation Class="PatchOperationAddCopy">
+		<xpath>/Defs/HediffDef[@ParentName="AA_MutantAddedBodyPartBase"][defName="AA_MutantHand"]/comps</xpath>
+		<fromxpath>/Defs/HediffDef[@ParentName="AA_MutantAddedBodyPartBase"][defName="AA_MutantArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]</fromxpath>
+	</Operation>
+	<Operation Class="PatchOperationRemove">
+		<xpath>/Defs/HediffDef[@ParentName="AA_MutantAddedBodyPartBase"][defName="AA_MutantArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]</xpath>
+	</Operation>
+
+
+</Patch>


### PR DESCRIPTION
The Alpha animal patch would cause errors since ToxicSensitivity has been replaced with ToxicResistence in 1.4. This patch fixes this :)